### PR TITLE
[automation] Feature automation i18n nullness

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
@@ -37,17 +37,15 @@ import org.osgi.framework.Bundle;
 public class ModuleI18nUtil {
 
     public static <T extends Module> List<T> getLocalizedModules(TranslationProvider i18nProvider, List<T> modules,
-            @Nullable Bundle bundle, String uid, String prefix, Locale locale) {
+            Bundle bundle, String uid, String prefix, @Nullable Locale locale) {
         List<T> lmodules = new ArrayList<>();
         for (T module : modules) {
             String label = getModuleLabel(i18nProvider, bundle, uid, module.getId(), module.getLabel(), prefix, locale);
-            String description = getModuleDescription(i18nProvider, bundle, uid, prefix, module.getId(),
-                    module.getDescription(), locale);
+            String description = getModuleDescription(i18nProvider, bundle, uid, module.getId(),
+                    module.getDescription(), prefix, locale);
             @Nullable
             T lmodule = createLocalizedModule(module, label, description);
-            if (lmodule != null) {
-                lmodules.add(lmodule);
-            }
+            lmodules.add(lmodule == null ? module : lmodule);
         }
         return lmodules;
     }
@@ -81,15 +79,14 @@ public class ModuleI18nUtil {
         return ModuleBuilder.createAction(module).withLabel(label).withDescription(description).build();
     }
 
-    private static @Nullable String getModuleLabel(TranslationProvider i18nProvider, @Nullable Bundle bundle,
-            String uid, String moduleName, @Nullable String defaultLabel, String prefix, @Nullable Locale locale) {
+    private static @Nullable String getModuleLabel(TranslationProvider i18nProvider, Bundle bundle, String uid,
+            String moduleName, @Nullable String defaultLabel, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleKey(prefix, uid, moduleName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static @Nullable String getModuleDescription(TranslationProvider i18nProvider, @Nullable Bundle bundle,
-            String uid, String prefix, String moduleName, @Nullable String defaultDescription,
-            @Nullable Locale locale) {
+    private static @Nullable String getModuleDescription(TranslationProvider i18nProvider, Bundle bundle, String uid,
+            String moduleName, @Nullable String defaultDescription, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleKey(prefix, uid, moduleName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -17,6 +17,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
@@ -36,10 +37,9 @@ import org.openhab.core.automation.type.ModuleType;
 import org.openhab.core.automation.type.Output;
 import org.openhab.core.automation.type.TriggerType;
 import org.osgi.framework.Bundle;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * @author Stefan Triller - Initial contribution
  */
 @Component
+@NonNullByDefault
 public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
 
     private final Logger logger = LoggerFactory.getLogger(ModuleTypeI18nServiceImpl.class);
@@ -56,8 +57,15 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
     /**
      * This field holds a reference to the service instance for internationalization support within the platform.
      */
-    private TranslationProvider i18nProvider;
-    private ConfigI18nLocalizationService localizationService;
+    private final TranslationProvider i18nProvider;
+    private final ConfigI18nLocalizationService localizationService;
+
+    @Activate
+    public ModuleTypeI18nServiceImpl(final @Reference TranslationProvider i18nProvider,
+            final @Reference ConfigI18nLocalizationService localizationService) {
+        this.i18nProvider = i18nProvider;
+        this.localizationService = localizationService;
+    }
 
     /**
      * This method is used to localize the {@link ModuleType}s.
@@ -68,8 +76,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
      */
     @Override
     public @Nullable ModuleType getModuleTypePerLocale(@Nullable ModuleType defModuleType, @Nullable Locale locale,
-            @Nullable Bundle bundle) {
-        if (locale == null || defModuleType == null || i18nProvider == null) {
+            Bundle bundle) {
+        if (defModuleType == null || locale == null) {
             return defModuleType;
         }
         String uid = defModuleType.getUID();
@@ -78,35 +86,35 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
         String ldescription = ModuleTypeI18nUtil.getLocalizedModuleTypeDescription(i18nProvider, bundle, uid,
                 defModuleType.getDescription(), locale);
 
-        List<ConfigDescriptionParameter> lconfigDescriptions = getLocalizedConfigDescriptionParameters(
+        List<ConfigDescriptionParameter> lconfigDescriptionParameters = getLocalizedConfigDescriptionParameters(
                 defModuleType.getConfigurationDescriptions(), ModuleTypeI18nUtil.MODULE_TYPE, uid, bundle, locale);
         if (defModuleType instanceof ActionType) {
-            return createLocalizedActionType((ActionType) defModuleType, bundle, uid, locale, lconfigDescriptions,
-                    llabel, ldescription);
+            return createLocalizedActionType((ActionType) defModuleType, bundle, uid, locale,
+                    lconfigDescriptionParameters, llabel, ldescription);
         }
         if (defModuleType instanceof ConditionType) {
-            return createLocalizedConditionType((ConditionType) defModuleType, bundle, uid, locale, lconfigDescriptions,
-                    llabel, ldescription);
+            return createLocalizedConditionType((ConditionType) defModuleType, bundle, uid, locale,
+                    lconfigDescriptionParameters, llabel, ldescription);
         }
         if (defModuleType instanceof TriggerType) {
-            return createLocalizedTriggerType((TriggerType) defModuleType, bundle, uid, locale, lconfigDescriptions,
-                    llabel, ldescription);
+            return createLocalizedTriggerType((TriggerType) defModuleType, bundle, uid, locale,
+                    lconfigDescriptionParameters, llabel, ldescription);
         }
         return null;
     }
 
-    private List<ConfigDescriptionParameter> getLocalizedConfigDescriptionParameters(
-            List<ConfigDescriptionParameter> parameters, String prefix, String uid, Bundle bundle, Locale locale) {
-        URI uri = null;
+    private @Nullable List<ConfigDescriptionParameter> getLocalizedConfigDescriptionParameters(
+            List<ConfigDescriptionParameter> parameters, String prefix, String uid, Bundle bundle,
+            @Nullable Locale locale) {
         try {
-            uri = new URI(prefix + ":" + uid + ".name");
+            return localizationService
+                    .getLocalizedConfigDescription(bundle,
+                            new ConfigDescription(new URI(prefix + ":" + uid + ".name"), parameters), locale)
+                    .getParameters();
         } catch (URISyntaxException e) {
             logger.error("Constructed invalid uri '{}:{}.name'", prefix, uid, e);
+            return null;
         }
-
-        ConfigDescription configDescription = new ConfigDescription(uri, parameters);
-
-        return localizationService.getLocalizedConfigDescription(bundle, configDescription, locale).getParameters();
     }
 
     /**
@@ -121,8 +129,9 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
      * @param ldescription is an ActionType localized description.
      * @return localized ActionType.
      */
-    private ActionType createLocalizedActionType(ActionType at, Bundle bundle, String moduleTypeUID, Locale locale,
-            List<ConfigDescriptionParameter> lconfigDescriptions, String llabel, String ldescription) {
+    private @Nullable ActionType createLocalizedActionType(ActionType at, Bundle bundle, String moduleTypeUID,
+            @Nullable Locale locale, @Nullable List<ConfigDescriptionParameter> lconfigDescriptions,
+            @Nullable String llabel, @Nullable String ldescription) {
         List<Input> inputs = ModuleTypeI18nUtil.getLocalizedInputs(i18nProvider, at.getInputs(), bundle, moduleTypeUID,
                 locale);
         List<Output> outputs = ModuleTypeI18nUtil.getLocalizedOutputs(i18nProvider, at.getOutputs(), bundle,
@@ -153,8 +162,9 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
      * @param ldescription is a ConditionType localized description.
      * @return localized ConditionType.
      */
-    private ConditionType createLocalizedConditionType(ConditionType ct, Bundle bundle, String moduleTypeUID,
-            Locale locale, List<ConfigDescriptionParameter> lconfigDescriptions, String llabel, String ldescription) {
+    private @Nullable ConditionType createLocalizedConditionType(ConditionType ct, Bundle bundle, String moduleTypeUID,
+            @Nullable Locale locale, @Nullable List<ConfigDescriptionParameter> lconfigDescriptions,
+            @Nullable String llabel, @Nullable String ldescription) {
         List<Input> inputs = ModuleTypeI18nUtil.getLocalizedInputs(i18nProvider, ct.getInputs(), bundle, moduleTypeUID,
                 locale);
         ConditionType lct = null;
@@ -183,8 +193,9 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
      * @param ldescription is a TriggerType localized description.
      * @return localized TriggerType.
      */
-    private TriggerType createLocalizedTriggerType(TriggerType tt, Bundle bundle, String moduleTypeUID, Locale locale,
-            List<ConfigDescriptionParameter> lconfigDescriptions, String llabel, String ldescription) {
+    private @Nullable TriggerType createLocalizedTriggerType(TriggerType tt, Bundle bundle, String moduleTypeUID,
+            @Nullable Locale locale, @Nullable List<ConfigDescriptionParameter> lconfigDescriptions,
+            @Nullable String llabel, @Nullable String ldescription) {
         List<Output> outputs = ModuleTypeI18nUtil.getLocalizedOutputs(i18nProvider, tt.getOutputs(), bundle,
                 moduleTypeUID, locale);
         TriggerType ltt = null;
@@ -199,24 +210,6 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
                     tt.getVisibility(), outputs);
         }
         return ltt;
-    }
-
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        this.i18nProvider = i18nProvider;
-    }
-
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        this.i18nProvider = null;
-    }
-
-    @Reference
-    protected void setConfigI18nLocalizationService(ConfigI18nLocalizationService localizationService) {
-        this.localizationService = localizationService;
-    }
-
-    protected void unsetConfigI18nLocalizationService(ConfigI18nLocalizationService localizationService) {
-        this.localizationService = null;
     }
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.type.Input;
@@ -29,25 +31,26 @@ import org.osgi.framework.Bundle;
  * @author Ana Dimova - Initial contribution
  * @author Yordan Mihaylov - updates related to api changes
  */
+@NonNullByDefault
 public class ModuleTypeI18nUtil {
 
     public static final String MODULE_TYPE = "module-type";
 
-    public static String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String defaultLabel, Locale locale) {
+    public static @Nullable String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleTypeKey(moduleTypeUID, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String defaultDescription, Locale locale) {
+    public static @Nullable String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleTypeKey(moduleTypeUID, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, List<Input> inputs, Bundle bundle,
-            String uid, Locale locale) {
+    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, @Nullable List<Input> inputs,
+            Bundle bundle, String uid, @Nullable Locale locale) {
         List<Input> linputs = new ArrayList<>();
         if (inputs != null) {
             for (Input input : inputs) {
@@ -63,8 +66,8 @@ public class ModuleTypeI18nUtil {
         return linputs;
     }
 
-    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, List<Output> outputs,
-            Bundle bundle, String uid, Locale locale) {
+    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, @Nullable List<Output> outputs,
+            Bundle bundle, String uid, @Nullable Locale locale) {
         List<Output> loutputs = new ArrayList<>();
         if (outputs != null) {
             for (Output output : outputs) {
@@ -80,27 +83,27 @@ public class ModuleTypeI18nUtil {
         return loutputs;
     }
 
-    private static String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, String defaultLabel, Locale locale) {
+    private static @Nullable String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
+            String inputName, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferInputKey(moduleTypeUID, inputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static String getInputDescription(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, String defaultDescription, Locale locale) {
+    private static @Nullable String getInputDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, String inputName, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferInputKey(moduleTypeUID, inputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle, String ruleTemplateUID,
-            String outputName, String defaultLabel, Locale locale) {
+    private static @Nullable String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String ruleTemplateUID, String outputName, String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferOutputKey(ruleTemplateUID, outputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String outputName, String defaultDescription, Locale locale) {
+    private static @Nullable String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, String outputName, String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferOutputKey(moduleTypeUID, outputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
@@ -36,7 +36,6 @@ public interface ModuleTypeI18nService {
      * @return the localized ModuleType
      */
     @Nullable
-    ModuleType getModuleTypePerLocale(@Nullable ModuleType defModuleType, @Nullable Locale locale,
-            @Nullable Bundle bundle);
+    ModuleType getModuleTypePerLocale(@Nullable ModuleType defModuleType, @Nullable Locale locale, Bundle bundle);
 
 }


### PR DESCRIPTION
- Added nullness annotations to automation i18n
- Added constructor injection to `ModuleTypeI18nServiceImpl`
- Fixed a potential bug in `ModuleI18nUtil.getLocalizedModules()` because of wrong parameter ordering
- Fixed potential `IllegalArgumentException` in `ModuleTypeI18nServiceImpl.getLocalizedConfigDescriptionParameters()` which will be thrown by `ConfigDescription` constructor if `URI` is `null`
 
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>